### PR TITLE
Allow overridden _SubParsersAction

### DIFF
--- a/argcomplete/__init__.py
+++ b/argcomplete/__init__.py
@@ -284,7 +284,7 @@ class CompletionFinder(object):
 
                         if not completer.completing:
                             self._orig_callable(parser, namespace, values, option_string=option_string)
-                        elif self._orig_class == argparse._SubParsersAction:
+                        elif issubclass(self._orig_class, argparse._SubParsersAction):
                             debug("orig class is a subparsers action: patching and running it")
                             patch(self._name_parser_map[values[0]])
                             self._orig_callable(parser, namespace, values, option_string=option_string)


### PR DESCRIPTION
Use an `issubclass` check rather than `==` to allow subclassing of `argparse._SubParsersAction` in applications.

Allows useful extensions such as aliasing of subcommands:
https://gist.github.com/sampsyo/471779
